### PR TITLE
Add TL-PA9020P Powerline kit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TL‑WPA8630P
 (Home Assistant Custom Integration)
 
-Monitor your TP‑Link **WPA8630 series** powerline Wi‑Fi extender from Home Assistant: Wi‑Fi client counts, SSIDs, channels, PLC link rates, and a “degraded PLC” binary sensor. The integration logs into the device, collects status (firmware/WLAN/clients/PLC), and exposes derived sensors for quick dashboards.
+Monitor your TP‑Link **WPA8630 series** powerline Wi‑Fi extender from Home Assistant: Wi‑Fi client counts, SSIDs, channels, PLC link rates, and a “degraded PLC” binary sensor. The integration logs into the device, collects status (firmware/WLAN/clients/PLC), and exposes derived sensors for quick dashboards. Devices without Wi‑Fi such as the **TL‑PA9020P KIT AV2000 Powerline Kit** are also supported; Wi‑Fi‑specific metrics are simply skipped.
 
 <p align="center">
   <img src="TL-WPA8630P-sensors.png" alt="Home Assistant entities screenshot" width="50%">


### PR DESCRIPTION
## Summary
- allow missing Wi-Fi endpoints so TL-PA9020P KIT AV2000 can be queried
- document support for TL-PA9020P devices

## Testing
- `python -m py_compile custom_components/TL_WPA4220.py`
- `python -m py_compile custom_components/__init__.py custom_components/config_flow.py custom_components/sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_68aad24796688333b5b606fefffc4c2c